### PR TITLE
Lint hidden folders 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+!/.jest
+!.prettierrc.js

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ...require("@smg-automotive/eslint-config/prettier"),
-}
+  ...require('@smg-automotive/eslint-config/prettier'),
+};


### PR DESCRIPTION
[FE-61](https://autoricardo.atlassian.net/browse/FE-61?atlOrigin=eyJpIjoiZDJlOGQ3YmYxOGI4NDMyODk5Y2E5OWFkYTY0Yzc3MjkiLCJwIjoiaiJ9)

## Motivation and context

By default, hidden folders are not linted by eslint, we need to add them to the eslint ignore file with a !. 
I tried to come up with something global that could be done at the eslint pkg level but could not find anything. 

## Before

.jest folder was not linted
.prettierc.js was not linted

## After

.jest folder and .prettierc.js are linted