### PR TITLE
chore: remove disabled eslint rules for naming convention

### DIFF
--- a/src/loadConfiguration.ts
+++ b/src/loadConfiguration.ts
@@ -43,7 +43,6 @@ const loadConfiguration = (): Configuration => {
 
   const configPath = path.resolve(envDir, env);
   const configuration = {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     CONFIG_ENV: env,
     VERSION: version,
     ...loadEnvFile(configPath),


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/IN-1719

## Motivation and context

Some ESLint configurations were set as global configs and respective lines for disabling them can be removed from the project.

## Before

ESLint lines for disabling uppercase property names and double leading underscore exist.

## After

ESLint lines for disabling uppercase property names and double leading underscore exist.
