### PR TITLE
chore: make dependabot handle security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # location of package.json
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "smg-automotive/frontend"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,6 @@ updates:
     directory: "/" # location of package.json
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0 # this option has no impact on security updates, which have a separate, internal limit of ten open pull requests
     reviewers:
       - "smg-automotive/frontend"


### PR DESCRIPTION
References [VSST-2918](https://smg-au.atlassian.net/browse/VSST-2918)

## Motivation and context

Configured dependabot to handle security updates only.

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]


[VSST-2918]: https://smg-au.atlassian.net/browse/VSST-2918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ