### PR TITLE
feat!: make configuration loading explicit and independent from process.cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ You can add local overrides in `.env/<CONFIG_ENV>.local`. This is useful for tem
 npm install @smg-automotive/configuration
 ```
 
+The package exports a `loadConfiguration` function.
+
 Add the following line to your `.gitignore`
 ```
 /.env/*.local
@@ -22,19 +24,74 @@ The configuration environment can be passed via `CONFIG_ENV` environment variabl
 $ CONFIG_ENV=stage-prod npm run dev
 ```
 
+## Upgrading
+
+The package no longer eagerly loads configuration when imported. The root export is now a
+`loadConfiguration` function, so update existing imports to call it explicitly:
+
+```
+// Before
+const configuration = require("@smg-automotive/configuration")
+
+// After
+const loadConfiguration = require("@smg-automotive/configuration")
+const configuration = loadConfiguration()
+```
+
+For side-effect only usage, call the required function:
+
+```
+// Before
+require("@smg-automotive/configuration")
+
+// After
+require("@smg-automotive/configuration")()
+```
+
+If the config can be loaded from a different working directory than the app directory, pass
+`envDir` explicitly:
+
+```
+const path = require("path")
+const loadConfiguration = require("@smg-automotive/configuration")
+
+const configuration = loadConfiguration({
+  envDir: path.join(__dirname, ".env")
+})
+```
+
 In a nextjs project, you can call `loadConfiguration()` in `next.config.js` and pass the result to next as `env`, see https://nextjs.org/docs/api-reference/next.config.js/environment-variables - configuration values will be available on `process.env` both client- and server-side
 
 ```
-const configuration = require("@smg-automotive/configuration")
+const loadConfiguration = require("@smg-automotive/configuration")
+
+const configuration = loadConfiguration()
+
 module.exports = {
   env: configuration
 }
 ```
 
-In any node process, simply require the package in your entry point and access variables on `process.env`. Do this as early in the file as possible, ie. before requiring any files that are accessing config variables
+If your `next.config.js` can be required by tooling from a different working directory, load the
+configuration from an explicit `.env` directory instead:
 
 ```
-require("@smg-automotive/configuration")
+const path = require("path")
+const loadConfiguration = require("@smg-automotive/configuration")
+
+const configuration = loadConfiguration({
+  envDir: path.join(__dirname, ".env")
+})
+
+module.exports = {
+  env: configuration
+}
+```
+
+In any node process, call the package in your entry point and access variables on `process.env`. Do this as early in the file as possible, ie. before requiring any files that are accessing config variables
+
+```
+require("@smg-automotive/configuration")()
 ```
 
 ## Development

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,10 +1,15 @@
+const prereleaseBranchName = '{!(+([0-9])?(.{+([0-9]),x}).x|main),**/*}';
+const prereleaseIdentifier =
+  '${name.replace(/[^0-9A-Za-z-]+/g, "-").replace(/^-+|-+$/g, "")}';
+
 module.exports = {
   branches: [
     'main',
     '+([0-9])?(.{+([0-9]),x}).x',
     {
-      name: '!(+([0-9])?(.{+([0-9]),x}).x|main)',
-      prerelease: `$\{ name }`,
+      name: prereleaseBranchName,
+      channel: prereleaseIdentifier,
+      prerelease: prereleaseIdentifier,
     },
   ],
 };

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,11 +2,26 @@
  * @jest-environment node
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
-import loadConfiguration from '@/src/loadConfiguration';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+import loadConfiguration from '@/src';
+
+const originalCwd = process.cwd();
+const temporaryDirectories: string[] = [];
 
 beforeEach(() => {
   process.env.CONFIG_ENV = '';
   process.env.NODE_ENV = '';
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 it('throws error when CONFIG_ENV is undefined', () => {
@@ -36,4 +51,51 @@ it('allows local overrides', () => {
   expect(configuration.VIDEO_URL).toEqual(
     'https://www.youtube.com/watch?v=XSqi5s3rfqk',
   );
+});
+
+it('does not load configuration when the root module is imported', () => {
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'configuration-pkg-'),
+  );
+  temporaryDirectories.push(temporaryDirectory);
+
+  process.env.CONFIG_ENV = 'missing';
+  process.chdir(temporaryDirectory);
+
+  let configurationModule: unknown;
+
+  expect(() => {
+    jest.isolateModules(() => {
+      configurationModule = require('@/src');
+    });
+  }).not.toThrow();
+
+  expect(typeof (configurationModule as { default: unknown }).default).toEqual(
+    'function',
+  );
+});
+
+it('loads configuration from an explicit env directory', () => {
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'configuration-pkg-'),
+  );
+  temporaryDirectories.push(temporaryDirectory);
+
+  const envDir = path.join(temporaryDirectory, '.env');
+  const toolingCwd = path.join(temporaryDirectory, 'tooling-cwd');
+
+  fs.mkdirSync(envDir);
+  fs.mkdirSync(toolingCwd);
+  fs.writeFileSync(
+    path.join(envDir, 'tooling'),
+    'VIDEO_URL=https://example.com/tooling\n',
+  );
+
+  process.env.CONFIG_ENV = 'tooling';
+  process.chdir(toolingCwd);
+
+  const configuration = loadConfiguration({ envDir });
+
+  expect(configuration.VIDEO_URL).toEqual('https://example.com/tooling');
+  expect(process.cwd()).toEqual(fs.realpathSync(toolingCwd));
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import loadConfiguration from './loadConfiguration';
-const configuration = loadConfiguration();
-
-export default configuration;
+export { default } from './loadConfiguration';
+export type {
+  Configuration,
+  LoadConfigurationOptions,
+} from './loadConfiguration';

--- a/src/loadConfiguration.ts
+++ b/src/loadConfiguration.ts
@@ -6,6 +6,10 @@ export interface Configuration {
   [key: string]: string | number | boolean;
 }
 
+export interface LoadConfigurationOptions {
+  envDir?: string;
+}
+
 if (typeof window !== 'undefined') {
   throw new Error(
     "It looks like you're loading the configuration in the browser. Use process.env.VARIABLE instead",
@@ -25,8 +29,12 @@ const loadEnvFile = (configPath: string) => {
   return configuration.parsed;
 };
 
-const loadConfiguration = (): Configuration => {
-  const envDir = path.join(process.cwd(), '.env');
+const loadConfiguration = (
+  options: LoadConfigurationOptions = {},
+): Configuration => {
+  const envDir = path.resolve(
+    options.envDir ?? path.join(process.cwd(), '.env'),
+  );
   const environments = fs.readdirSync(envDir);
 
   const nodeEnv = process.env.NODE_ENV || 'development';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "exclude": ["dist", "node_modules", "src/**/*.test.ts*"],
   "include": ["src"]
 }


### PR DESCRIPTION
Implements [FED-1188](https://smg-au.atlassian.net/browse/FED-1188)

## Summary

- Change the root `@smg-automotive/configuration` export from an eagerly-loaded configuration object to the `loadConfiguration` function.
- Add optional `envDir` support so tooling can load `.env/<CONFIG_ENV>` from the app directory even when `process.cwd()` points elsewhere.
- Document the breaking migration path and the explicit `envDir` usage for Next/Nx-style tooling.
- Add tests for non-eager root imports and explicit env directory loading.

## Breaking change

Consumers must now call the package export explicitly:

```js
const loadConfiguration = require("@smg-automotive/configuration")
const configuration = loadConfiguration()
```

Side-effect-only usage changes from:

```js
require("@smg-automotive/configuration")
```

to:

```js
require("@smg-automotive/configuration")()
```

## Review

- Subagent review completed before commit with no blocking findings.
- One P3 residual noted: the direct CJS package shape is covered by manual dist smoke rather than a committed Jest test.

## Verification

- `npm test -- --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Dist smoke for CJS/ESM callable loader exports and `loadConfiguration({ envDir })`

[FED-1188]: https://smg-au.atlassian.net/browse/FED-1188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ